### PR TITLE
Correct typo preventing :pedestal :uberwar option

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -25,16 +25,21 @@ These are the available options and some of their defaults.  In your `project.cl
 
 ### Use this for user-level plugins:
 
-Put `[ohpauleez/lein-pedestal "0.1.0-beta9"]` into the `:plugins` vector of your
+Put `[ohpauleez/lein-pedestal "0.1.1-beta9"]` into the `:plugins` vector of your
 `:user` profile or...
 
 ### Use this for project-level plugins:
 
-Put `[ohpauleez/lein-pedestal "0.1.0-beta9"]` into the `:plugins` vector of your project.clj.
+Put `[ohpauleez/lein-pedestal "0.1.1-beta9"]` into the `:plugins` vector of your project.clj.
 
-FIXME: and add an example usage that actually makes sense:
+
+### Commands
 
     $ lein pedestal [war | uberwar | help]
+
+You can supply a war/jar name from the command line:
+
+    $ lein pedestal uberwar my-project.war
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ohpauleez/lein-pedestal "0.1.0-beta9"
+(defproject ohpauleez/lein-pedestal "0.1.1-beta9"
   :description "Pedestal plugin for Leiningen"
   :url "https://github.com/ohpauleez/lein-pedestal"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/pedestal/uberwar.clj
+++ b/src/leiningen/pedestal/uberwar.clj
@@ -19,7 +19,7 @@
 (defn uberwar
   "Create a $PROJECT-$VERSION.war file with all the dependencies."
   ([project]
-   (uberwar project (get-in project [:predestal :uberwar-name]
+   (uberwar project (get-in project [:pedestal :uberwar-name]
                             (war/war-name project "-standalone"))))
   ([project uberwar-name-str]
    (let [war-path (war/war-file-path project uberwar-name-str)]


### PR DESCRIPTION
Just a typo. This resolves https://github.com/ohpauleez/lein-pedestal/issues/2

I bumped the version to prep for deploy, and added an example of the command-line renaming to the readme.
